### PR TITLE
Remove better_errors

### DIFF
--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -27,7 +27,6 @@ gem 'uglifier'
 gem 'unicorn'
 
 group :development do
-  gem 'better_errors'
   gem 'foreman'
   gem 'spring'
   gem 'spring-commands-rspec'


### PR DESCRIPTION
- We're using unicorn as our default server
- better_errors is not compatible with unicorn
- Instead of error context, you just see "Session expired"
- The default Rails behavior is more reliable

charliesome/better_errors#40
