### PR TITLE
Update `bin/setup` script to avoid rake errors

### DIFF
--- a/templates/bin_setup
+++ b/templates/bin_setup
@@ -8,13 +8,13 @@ set -e
 # Set up Ruby dependencies via Bundler
 bundle install
 
-# Set up the database
-bundle exec rake db:setup
-
 # Set up configurable environment variables
 if [ ! -f .env ]; then
   cp .sample.env .env
 fi
+
+# Set up the database
+bundle exec rake db:setup
 
 # Pick a port for Foreman
 echo "port: 7000" > .foreman


### PR DESCRIPTION
In some situations we see errors due to a missing env variables
needed by Rails to bootstrap.
Setting `.env` file before calling `rake` fix it
