### PR TITLE
Escape Erb in secrets.yml

### DIFF
--- a/templates/secrets.yml
+++ b/templates/secrets.yml
@@ -1,5 +1,5 @@
 default: &default
-  secret_key_base: <%= ENV['SECRET_KEY_BASE'] %>
+  secret_key_base: <%%= ENV['SECRET_KEY_BASE'] %>
 
 development:
   <<: *default


### PR DESCRIPTION
Fixes issue where `secret_key_base` in `config/secrets.yml` was blank,
missing `<%= ENV['SECRET_KEY_BASE'] %>`.
