### PR TITLE
Require rails_12factor gem only on Heroku

### DIFF
--- a/lib/roll/app_builder.rb
+++ b/lib/roll/app_builder.rb
@@ -11,6 +11,11 @@ module Roll
       template 'ruby-version.erb', '.ruby-version'
     end
 
+    def setup_heroku_specific_gems
+      inject_into_file 'Gemfile', "\n\s\sgem 'rails_12factor'",
+        after: /group :staging, :production do/
+    end
+
     def use_postgres_config_template
       template 'postgresql_database.yml.erb', 'config/database.yml',
         force: true

--- a/lib/roll/generators/app_generator.rb
+++ b/lib/roll/generators/app_generator.rb
@@ -47,6 +47,11 @@ module Roll
     def customize_gemfile
       build :replace_gemfile
       build :set_ruby_to_version_being_used
+
+      if options[:heroku]
+        build :setup_heroku_specific_gems
+      end
+
       bundle_command 'install'
     end
 

--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -52,5 +52,4 @@ end
 
 group :staging, :production do
   gem 'newrelic_rpm', '>= 3.7.3'
-  gem 'rails_12factor'
 end


### PR DESCRIPTION
In non-Heroku environments, the `rails_12factor` gem prevents production/staging logs from being generated.
