### PR TITLE
Ensure EMAIL_RECIPIENTS is set on staging

### DIFF
--- a/templates/staging.rb
+++ b/templates/staging.rb
@@ -1,3 +1,3 @@
 require_relative 'production'
 
-Mail.register_interceptor RecipientInterceptor.new(ENV['EMAIL_RECIPIENTS'])
+Mail.register_interceptor RecipientInterceptor.new(ENV.fetch('EMAIL_RECIPIENTS'))


### PR DESCRIPTION
When the variable isn't set, mail deliveries will raise:

```
ArgumentError: An SMTP To address is required to send a message. Set the message
smtp_envelope_to, to, cc, or bcc address
```
