### PR TITLE
Add `.hound.yml` config file

### DIFF
--- a/lib/roll/app_builder.rb
+++ b/lib/roll/app_builder.rb
@@ -74,6 +74,10 @@ module Roll
       inject_into_class 'config/application.rb', 'Application', config
     end
 
+    def configure_hound
+      template 'hound.yml.erb', '.hound.yml'
+    end
+
     def set_up_factory_girl_for_rspec
       copy_file 'factory_girl_rspec.rb', 'spec/support/factory_girl.rb'
     end

--- a/lib/roll/generators/app_generator.rb
+++ b/lib/roll/generators/app_generator.rb
@@ -81,6 +81,7 @@ module Roll
       build :raise_on_unpermitted_parameters
       build :provide_setup_script
       build :configure_generators
+      build :configure_hound
     end
 
     def setup_test_environment

--- a/templates/hound.yml.erb
+++ b/templates/hound.yml.erb
@@ -1,0 +1,46 @@
+AllCops:
+  Include:
+    - 'Gemfile'
+    - 'Rakefile'
+  Exclude:
+    - 'bin/*'
+    - 'db/schema.rb'
+    - 'db/migrate/*'
+
+ParameterLists:
+  Max: 4
+  CountKeywordArgs: true
+
+ClassLength:
+  Max: 100
+
+LineLength:
+  Enabled: false
+
+MethodLength:
+  CountComments: false
+  Max: 15
+
+# Avoid more than `Max` levels of nesting.
+BlockNesting:
+  Max: 2
+
+# Disable documentation checking until a class needs to be documented once
+Documentation:
+  Enabled: false
+
+# Enforce Ruby 1.9-compatible hash syntax
+HashSyntax:
+  EnforcedStyle: ruby19
+
+EmptyLinesAroundAccessModifier:
+  Enabled: true
+
+# Align ends correctly
+EndAlignment:
+  AlignWith: variable
+
+# Indentation of when/else
+CaseIndentation:
+  IndentWhenRelativeTo: end
+  IndentOneStep: false


### PR DESCRIPTION
Add by default a `hound.yml` config file with some overrides to the default rubocop cops, based on our standards.
