### PR TITLE
Inject code for mailers previews into application.rb

### DIFF
--- a/lib/roll/app_builder.rb
+++ b/lib/roll/app_builder.rb
@@ -74,6 +74,18 @@ module Roll
       inject_into_class 'config/application.rb', 'Application', config
     end
 
+    def configure_mailers_preview_path
+      config = <<-RUBY
+
+
+  # Specific mailers path
+  config.action_mailer.preview_path = Rails.root + '/spec/mailers/previews'
+      RUBY
+
+      empty_directory_with_keep_file 'spec/mailers/previews'
+      inject_into_file 'config/environments/development.rb', config, before: "\nend"
+    end
+
     def configure_hound
       template 'hound.yml.erb', '.hound.yml'
     end

--- a/lib/roll/generators/app_generator.rb
+++ b/lib/roll/generators/app_generator.rb
@@ -133,6 +133,7 @@ module Roll
       build :setup_default_rake_task
       build :configure_unicorn
       build :setup_foreman
+      build :configure_mailers_preview_path
     end
 
     def setup_zurb_foundation


### PR DESCRIPTION
By default, mailers previews are searched in Rails.root/tests/mailers/previews. As we use rspec, this default path has to be changed.
