### PR TITLE
Update hound cop rules

### DIFF
--- a/templates/hound.yml.erb
+++ b/templates/hound.yml.erb
@@ -48,3 +48,11 @@ CaseIndentation:
 # Enforce single_quotes
 StringLiterals:
   EnforcedStyle: single_quotes
+
+# Style of children definitions at classes and modules
+ClassAndModuleChildren:
+  Enabled: false
+
+# Guard clause
+GuardClause:
+  Enabled: false


### PR DESCRIPTION
- Disable `ClassAndModuleChildren` to avoid `'Use nested module/class definitions instead of compact style.'`
- Disable `GuardClause` to avoid `Use a guard clause instead of wrapping the code inside a conditional expression.'`
