### PR TITLE
Upgrade to RSpec3

### DIFF
--- a/lib/roll/app_builder.rb
+++ b/lib/roll/app_builder.rb
@@ -100,7 +100,9 @@ module Roll
 
     def configure_rspec
       remove_file 'spec/spec_helper.rb'
-      template 'spec_helper.rb', 'spec/spec_helper.rb'
+      remove_file 'spec/rails_helper.rb'
+      template 'rails_helper.rb', 'spec/rails_helper.rb'
+      copy_file 'spec_helper.rb', 'spec/spec_helper.rb'
     end
 
     def configure_background_jobs_for_rspec

--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -38,11 +38,11 @@ end
 group :development, :test do
   gem 'dotenv-rails'
   gem 'factory_girl_rails'
-  gem 'rspec-rails', '~> 2.14.0'
+  gem 'rspec-rails', '~> 3.0.0'
 end
 
 group :test do
-  gem 'capybara-webkit', '>= 1.0.0'
+  gem 'capybara-webkit', '>= 1.2.0'
   gem 'database_cleaner'
   gem 'shoulda-matchers', require: false
   gem 'simplecov', require: false

--- a/templates/rails_helper.rb
+++ b/templates/rails_helper.rb
@@ -1,0 +1,27 @@
+require 'simplecov'
+SimpleCov.start 'rails'
+
+ENV['RAILS_ENV'] = 'test'
+
+require File.expand_path('../../config/environment', __FILE__)
+
+require 'rspec/rails'
+require 'shoulda/matchers'
+
+Dir[Rails.root.join('spec/support/**/*.rb')].each { |file| require file }
+
+module Features
+  # Extend this module in spec/support/features/*.rb
+end
+
+RSpec.configure do |config|
+  config.include Features, type: :feature
+  config.infer_base_class_for_anonymous_controllers = false
+  config.infer_spec_type_from_file_location!
+<% if using_active_record? -%>
+  config.use_transactional_fixtures = false
+<% end -%>
+end
+
+ActiveRecord::Migration.maintain_test_schema!
+Capybara.javascript_driver = :webkit

--- a/templates/spec_helper.rb
+++ b/templates/spec_helper.rb
@@ -1,34 +1,16 @@
-require 'simplecov'
-SimpleCov.start 'rails'
-
-ENV['RAILS_ENV'] = 'test'
-
-require File.expand_path('../../config/environment', __FILE__)
-
-require 'rspec/rails'
-require 'shoulda/matchers'
 require 'webmock/rspec'
 
-Dir[Rails.root.join('spec/support/**/*.rb')].each { |file| require file }
-
-module Features
-  # Extend this module in spec/support/features/*.rb
-end
-
+# http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
-  config.expect_with :rspec do |c|
-    c.syntax = :expect
+  config.expect_with :rspec do |expectations|
+    expectations.syntax = :expect
   end
 
-  config.fail_fast = true
-  config.include Features, type: :feature
-  config.infer_base_class_for_anonymous_controllers = false
-  config.order = 'random'
-<% if using_active_record? -%>
-  config.use_transactional_fixtures = false
-<% end -%>
+  config.mock_with :rspec do |mocks|
+    mocks.syntax = :expect
+  end
+
+  config.order = :random
 end
 
-ActiveRecord::Migration.maintain_test_schema!
-Capybara.javascript_driver = :webkit
 WebMock.disable_net_connect!(allow_localhost: true)


### PR DESCRIPTION
RSpec 3.x introduces a `spec/rails_helper.rb` file
which contains all dependencies necessary to run specs that need Rails.
- Move Rails-specific things to rails_helper.rb.
- Require spec_helper.rb from rails_helper.rb.
- We do not need to require `spec_helper` manually.
  It is required for us in `.rspec`:
    --color
    --require spec_helper
