### PR TITLE
Remove `newrelic` gem version constraints

### DIFF
--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -53,5 +53,5 @@ group :test do
 end
 
 group :staging, :production do
-  gem 'newrelic_rpm', '>= 3.7.3'
+  gem 'newrelic_rpm'
 end


### PR DESCRIPTION
- Specified version gives alert that newrelic "requires a security update for
  their Postgres explain plan support"
