### PR TITLE
Use PostgreSQL 9.3 on Travis CI

### DIFF
--- a/templates/travis.yml.erb
+++ b/templates/travis.yml.erb
@@ -1,6 +1,9 @@
 language: ruby
 rvm: <%= RUBY_VERSION %>
 
+addons:
+  - postgresql: '9.3'
+
 cache: bundler
 
 before_install:


### PR DESCRIPTION
Heroku's default is Postgres 9.3 [1](https://devcenter.heroku.com/articles/heroku-postgresql#version-support), but Travis' default is Postgres 9.1 [2](http://docs.travis-ci.com/user/using-postgresql/)
