### PR TITLE
Update the default Hound config to enforce leading dots style

### DIFF
--- a/templates/hound.yml.erb
+++ b/templates/hound.yml.erb
@@ -21,30 +21,27 @@ MethodLength:
   CountComments: false
   Max: 15
 
-# Avoid more than `Max` levels of nesting.
 BlockNesting:
   Max: 2
 
-# Disable documentation checking until a class needs to be documented once
 Documentation:
   Enabled: false
 
-# Enforce Ruby 1.9-compatible hash syntax
 HashSyntax:
   EnforcedStyle: ruby19
 
 EmptyLinesAroundAccessModifier:
   Enabled: true
 
-# Align ends correctly
 EndAlignment:
   AlignWith: variable
 
-# Indentation of when/else
 CaseIndentation:
   IndentWhenRelativeTo: end
   IndentOneStep: false
 
-# Enforce single_quotes
 StringLiterals:
   EnforcedStyle: single_quotes
+
+DotPosition:
+  EnforcedStyle: leading


### PR DESCRIPTION
* based on our style guideline craftsmen/guides#10