### PR TITLE
Use new Travis Docker based architecture

### DIFF
--- a/templates/travis.yml.erb
+++ b/templates/travis.yml.erb
@@ -1,6 +1,8 @@
 language: ruby
 rvm: <%= RUBY_VERSION %>
 
+sudo: false
+
 addons:
   - postgresql: '9.3'
 


### PR DESCRIPTION
Travis pushed a new architecture, based on docker. As we generally don't need to `sudo` in our travis configs, it seems a good idea to use this new (faster) architecture by default.

Post : http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/