### PR TITLE
Configure application for raising exception on unpermitted parameters

### DIFF
--- a/lib/roll/app_builder.rb
+++ b/lib/roll/app_builder.rb
@@ -45,15 +45,15 @@ module Roll
     def raise_on_unpermitted_parameters
       action_on_unpermitted_parameters = <<-RUBY
 
-  # Raise an ActionController::UnpermittedParameters exception when
-  # a parameter is not explcitly permitted but is passed anyway.
-  config.action_controller.action_on_unpermitted_parameters = :raise
+    # Raise an ActionController::UnpermittedParameters exception when
+    # a parameter is not explicitly permitted but is passed anyway.
+    config.action_controller.action_on_unpermitted_parameters = :raise
+
       RUBY
-      inject_into_file(
-        "config/environments/development.rb",
-        action_on_unpermitted_parameters,
-        before: "\nend"
-      )
+
+      inject_into_class 'config/application.rb',
+                        'Application',
+                        action_on_unpermitted_parameters
     end
 
     def provide_setup_script

--- a/lib/roll/generators/app_generator.rb
+++ b/lib/roll/generators/app_generator.rb
@@ -79,7 +79,6 @@ module Roll
     def setup_development_environment
       say 'Setting up the development environment'
       build :raise_on_delivery_errors
-      build :raise_on_unpermitted_parameters
       build :provide_setup_script
       build :provide_dev_prime_task
       build :configure_generators
@@ -137,6 +136,7 @@ module Roll
       build :configure_unicorn
       build :setup_foreman
       build :configure_mailers_preview_path
+      build :raise_on_unpermitted_parameters
     end
 
     def setup_bourbon


### PR DESCRIPTION
Rails behavior is not the same about handling unpermitted parameters between `development` environment and `test` or `production` environments. It raises an exception when unpermitted parameters are given to a controller action only in `development` environment. In other environments, unpermitted parameters are just ignored.

This configuration forces Rails to raise exceptions for all environments, which should be a good idea.