### PR TITLE
Use the ISO8601 format for timestamps in serialized JSONs

### DIFF
--- a/lib/roll/app_builder.rb
+++ b/lib/roll/app_builder.rb
@@ -283,6 +283,7 @@ end
 
     def copy_miscellaneous_files
       copy_file 'errors.rb', 'config/initializers/errors.rb'
+      copy_file 'json_encoding.rb', 'config/initializers/json_encoding.rb'
     end
 
     def customize_error_pages

--- a/templates/json_encoding.rb
+++ b/templates/json_encoding.rb
@@ -1,0 +1,1 @@
+ActiveSupport::JSON::Encoding.time_precision = 0


### PR DESCRIPTION
By default, Rails uses millisecond-level precision. This changes it to second-level precision, in an initializer, to avoid writing .iso8601 in our serializers for each datetime object.
See https://github.com/interagent/http-api-design#provide-standard-timestamps

Before
```json
"created_at": "2015-02-03T03:02:16.781Z"
``` 

After
```json
"created_at": "2015-02-03T03:02:16Z"
```

Tried successfully for https://github.com/craftsmen/1dtouch-music