### PR TITLE
Set `RAILS_SERVE_STATIC_FILES` for Heroku apps

### DIFF
--- a/lib/roll/app_builder.rb
+++ b/lib/roll/app_builder.rb
@@ -329,6 +329,7 @@ end
       %w(staging production).each do |environment|
         run "heroku create #{app_name}-#{environment} --remote #{environment} --region eu"
         run "heroku config:set RACK_ENV=#{environment} RAILS_ENV=#{environment} --remote #{environment}"
+        run "heroku config:set RAILS_SERVE_STATIC_FILES=true --remote #{environment}"
       end
     end
 


### PR DESCRIPTION
We are using Rails 4 to serve static assets, but it needs
`ENV['RAILS_SERVE_STATIC_FILES']` to be present to make it happen.

This sets it for Heroku's staging and production environments.