### PR TITLE
Remove ZURB Foundation in favor of Bourbon family

### DIFF
--- a/lib/roll/app_builder.rb
+++ b/lib/roll/app_builder.rb
@@ -275,10 +275,13 @@ end
       copy_file 'Procfile', 'Procfile'
     end
 
-    def setup_zurb_foundation
-      copy_file 'foundation_and_overrides.scss', 'app/assets/stylesheets/foundation_and_overrides.scss'
+    def setup_bourbon
       remove_file 'app/assets/stylesheets/application.css'
-      copy_file 'application.css.scss', 'app/assets/stylesheets/application.css.scss'
+      copy_file 'application.scss', 'app/assets/stylesheets/application.scss'
+    end
+
+    def install_bitters
+      run 'bitters install --path app/assets/stylesheets'
     end
 
     def copy_miscellaneous_files

--- a/lib/roll/generators/app_generator.rb
+++ b/lib/roll/generators/app_generator.rb
@@ -35,7 +35,8 @@ module Roll
       invoke :setup_secret_token
       invoke :create_roll_views
       invoke :configure_app
-      invoke :setup_zurb_foundation
+      invoke :setup_bourbon
+      invoke :install_bitters
       invoke :copy_miscellaneous_files
       invoke :customize_error_pages
       invoke :remove_routes_comment_lines
@@ -138,9 +139,14 @@ module Roll
       build :configure_mailers_preview_path
     end
 
-    def setup_zurb_foundation
-      say 'Setting up ZURB foundation'
-      build :setup_zurb_foundation
+    def setup_bourbon
+      say 'Setting up Bourbon and Neat stylesheets'
+      build :setup_bourbon
+    end
+
+    def install_bitters
+      say 'Install Bitters'
+      build :install_bitters
     end
 
     def copy_miscellaneous_files

--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 ruby '<%= RUBY_VERSION %>'
 
+gem 'bourbon', '~> 4.1.0'
 gem 'coffee-rails', '~> 4.1.0'
 <% if using_active_record? -%>
 gem 'delayed_job_active_record'
@@ -10,7 +11,6 @@ gem 'delayed_job_active_record'
 gem 'delayed_job_mongoid', github: 'collectiveidea/delayed_job_mongoid'
 <% end -%>
 gem 'email_validator'
-gem 'foundation-rails', '~> 5.0'
 gem 'high_voltage'
 gem 'jbuilder', '~> 2.0'
 gem 'jquery-rails'
@@ -20,6 +20,8 @@ gem 'pg'
 <% if using_mongoid? -%>
 gem 'mongoid', github: 'mongoid/mongoid'
 <% end -%>
+gem 'neat', '~> 1.7.0'
+gem 'normalize-rails', '~> 3.0.0'
 gem 'rack-timeout'
 gem 'rails', '~> 4.2.0'
 gem 'recipient_interceptor'

--- a/templates/_flashes.html.erb
+++ b/templates/_flashes.html.erb
@@ -1,6 +1,7 @@
-<% flash.each do |key, value| %>
-  <div data-alert class="alert-box <%= key %>">
-    <%= value %>
-    <a href="#" class="close">&times;</a>
+<% if flash.any? %>
+  <div id="flash">
+    <% flash.each do |key, value| -%>
+      <div class="flash-<%= key %>"><%= value %></div>
+    <% end -%>
   </div>
 <% end %>

--- a/templates/application.css.scss
+++ b/templates/application.css.scss
@@ -1,2 +1,0 @@
-@import 'normalize';
-@import 'foundation_and_overrides';

--- a/templates/application.scss
+++ b/templates/application.scss
@@ -1,0 +1,7 @@
+@charset 'utf-8';
+
+@import 'normalize-rails';
+@import 'bourbon';
+@import 'base/grid-settings';
+@import 'neat';
+@import 'base/base';

--- a/templates/foundation_and_overrides.scss
+++ b/templates/foundation_and_overrides.scss
@@ -1,3 +1,0 @@
-@import 'foundation/functions';
-
-@import 'foundation';


### PR DESCRIPTION
Now we moved all from Foundation to Bourbon, time for a cleanup :+1: 
This removes Foundation setup and replace it by Bourbon, neat and Bitters.
It rename `application.css.scss` ~> `application.scss` as the former will be deprecated yb sass-rails 5.0