### PR TITLE
Remove `jbuilder` from the default Gemfile

### DIFF
--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -12,7 +12,6 @@ gem 'delayed_job_mongoid', github: 'collectiveidea/delayed_job_mongoid'
 <% end -%>
 gem 'email_validator'
 gem 'high_voltage'
-gem 'jbuilder', '~> 2.0'
 gem 'jquery-rails'
 <% if using_active_record? -%>
 gem 'pg'


### PR DESCRIPTION
We no longer use Jbuilder in our projects but prefer AMS.
This removes the gem from our default Gemfile.