### PR TITLE
Enable JavaScript and SCSS style checking by Hound

### DIFF
--- a/lib/roll/app_builder.rb
+++ b/lib/roll/app_builder.rb
@@ -94,7 +94,10 @@ module Roll
     end
 
     def configure_hound
-      template 'hound.yml.erb', '.hound.yml'
+      copy_file 'hound.yml', '.hound.yml'
+      copy_file 'style_guides/ruby.yml', 'config/style_guides/ruby.yml'
+      copy_file 'style_guides/javascript.json', 'config/style_guides/javascript.json'
+      copy_file 'style_guides/javascript_ignore', 'config/style_guides/.javascript_ignore'
     end
 
     def set_up_factory_girl_for_rspec

--- a/templates/hound.yml
+++ b/templates/hound.yml
@@ -1,0 +1,11 @@
+ruby:
+  enabled: true
+  config_file: config/style_guides/ruby.yml
+
+java_script:
+  enabled: true
+  config_file: config/style_guides/javascript.json
+  ignore_file: config/style_guides/.javascript_ignore
+
+scss:
+  enabled: true

--- a/templates/style_guides/javascript.json
+++ b/templates/style_guides/javascript.json
@@ -1,0 +1,3 @@
+{
+  "camelcase": false
+}

--- a/templates/style_guides/javascript_ignore
+++ b/templates/style_guides/javascript_ignore
@@ -1,0 +1,1 @@
+vendor/assets/javascripts/*.js

--- a/templates/style_guides/ruby.yml
+++ b/templates/style_guides/ruby.yml
@@ -15,17 +15,11 @@ ClassLength:
   Max: 100
 
 LineLength:
-  Enabled: false
+  Enabled: 100
 
 MethodLength:
   CountComments: false
   Max: 15
-
-BlockNesting:
-  Max: 2
-
-Documentation:
-  Enabled: false
 
 HashSyntax:
   EnforcedStyle: ruby19


### PR DESCRIPTION
Some of the default rules are overridden to match our style guide.
A new guideline is introduced here: using snake case for JavaScript code.
Are we all :ok_hand: for it?

Follow up to https://github.com/craftsmen/1dtouch-music/pull/235#discussion_r24981935 and https://github.com/craftsmen/1dtouch-music/pull/237