### PR TITLE
Heroku defaults

### DIFF
--- a/lib/roll/app_builder.rb
+++ b/lib/roll/app_builder.rb
@@ -331,9 +331,9 @@ end
       run 'git init'
     end
 
-    def create_heroku_apps
+    def create_heroku_apps(flags)
       %w(staging production).each do |environment|
-        run "heroku create #{app_name}-#{environment} --remote #{environment} --region eu"
+        run "heroku create #{app_name}-#{environment} --remote #{environment} #{flags}"
         run "heroku config:set RACK_ENV=#{environment} RAILS_ENV=#{environment} --remote #{environment}"
         run "heroku config:set RAILS_SERVE_STATIC_FILES=true --remote #{environment}"
       end

--- a/lib/roll/generators/app_generator.rb
+++ b/lib/roll/generators/app_generator.rb
@@ -13,8 +13,11 @@ module Roll
     class_option :mongoid, type: :boolean, aliases: '-M', default: false,
       desc: 'Use Mongoid ODM'
 
+    class_option :heroku_flags, type: :string, default: '--region eu',
+      desc: 'Set extra Heroku flags'
+
     class_option :skip_heroku, type: :boolean, default: false,
-      desc: 'Create staging Heroku apps'
+      desc: 'Skip creating staging and production Heroku apps'
 
     class_option :skip_test_unit, type: :boolean, aliases: '-T', default: true,
       desc: 'Skip Test::Unit files'
@@ -182,7 +185,7 @@ module Roll
     def create_heroku_apps
       if !options[:skip_heroku]
         say 'Creating Heroku apps'
-        build :create_heroku_apps
+        build :create_heroku_apps, options[:heroku_flags]
         build :set_heroku_remotes
         build :set_heroku_rails_secrets
         build :provide_deploy_script

--- a/lib/roll/generators/app_generator.rb
+++ b/lib/roll/generators/app_generator.rb
@@ -13,7 +13,7 @@ module Roll
     class_option :mongoid, type: :boolean, aliases: '-M', default: false,
       desc: 'Use Mongoid ODM'
 
-    class_option :heroku, type: :boolean, aliases: '-H', default: false,
+    class_option :skip_heroku, type: :boolean, default: false,
       desc: 'Create staging Heroku apps'
 
     class_option :skip_test_unit, type: :boolean, aliases: '-T', default: true,
@@ -180,7 +180,7 @@ module Roll
     end
 
     def create_heroku_apps
-      if options[:heroku]
+      if !options[:skip_heroku]
         say 'Creating Heroku apps'
         build :create_heroku_apps
         build :set_heroku_remotes


### PR DESCRIPTION
This makes creating and configuring Heroku apps the default, as all of our past months projects has been deployed to Heroku, but for some of them we configured Heroku apps manually later on, by adding required gems, configuring static assets serving, updating `bin/setup` script with Heroku remotes ...
Heroku can be skipped though with `--skip_heroku` option.

It introduces also `--heroku-flags` option where we can pass in any Heroku option like the region (was hardcoded before to EU) or some addons.

    roll app --heroku-flags "--region eu --addons newrelic,pgbackups,sendgrid"

