### PR TITLE
Replace travis addons array by a hash

### DIFF
--- a/templates/travis.yml.erb
+++ b/templates/travis.yml.erb
@@ -4,7 +4,7 @@ rvm: <%= RUBY_VERSION %>
 sudo: false
 
 addons:
-  - postgresql: '9.3'
+  postgresql: '9.3'
 
 cache: bundler
 


### PR DESCRIPTION
I have just seen that we were still using Postgresql 9.1 on Travis, due to a typo in addons listing (we are not the only ones: https://github.com/travis-ci/travis-ci/issues/2983#issuecomment-75420000): we were defining an yml array where Travis was waiting for a hash.

This fixes the `.travis.yml` template.