### PR TITLE
Remove the configured `ActionMailer` preview path

### DIFF
--- a/lib/roll/app_builder.rb
+++ b/lib/roll/app_builder.rb
@@ -81,18 +81,6 @@ module Roll
       inject_into_class 'config/application.rb', 'Application', config
     end
 
-    def configure_mailers_preview_path
-      config = <<-RUBY
-
-
-  # Specific mailers path
-  config.action_mailer.preview_path = Rails.root.join('spec/mailers/previews')
-      RUBY
-
-      empty_directory_with_keep_file 'spec/mailers/previews'
-      inject_into_file 'config/environments/development.rb', config, before: "\nend"
-    end
-
     def configure_hound
       copy_file 'hound.yml', '.hound.yml'
       copy_file 'style_guides/ruby.yml', 'config/style_guides/ruby.yml'

--- a/lib/roll/generators/app_generator.rb
+++ b/lib/roll/generators/app_generator.rb
@@ -138,7 +138,6 @@ module Roll
       build :setup_default_rake_task
       build :configure_unicorn
       build :setup_foreman
-      build :configure_mailers_preview_path
       build :raise_on_unpermitted_parameters
     end
 


### PR DESCRIPTION
Because it's the default configured path since RSpec 3.2.0, and RSpec warn about it:
`WARNING: Action Mailer preview_path is not the RSpec default.`

I think RSpec should honor a configured `config.action_mailer.preview_path` and don't warn about it when it's explicitly set.

https://github.com/rspec/rspec-rails/pull/1236