### PR TITLE
Remove forgotten line from app_builder

### DIFF
--- a/lib/roll/app_builder.rb
+++ b/lib/roll/app_builder.rb
@@ -85,7 +85,6 @@ module Roll
       copy_file 'hound.yml', '.hound.yml'
       copy_file 'style_guides/ruby.yml', 'config/style_guides/ruby.yml'
       copy_file 'style_guides/javascript.json', 'config/style_guides/javascript.json'
-      copy_file 'style_guides/javascript_ignore', 'config/style_guides/.javascript_ignore'
     end
 
     def set_up_factory_girl_for_rspec


### PR DESCRIPTION
When removing the javascript_ignore, we forgot to remove copying the file in app_builder.rb. This was breaking roll.

Maybe we should start thinking about unit testing roll, or rolling a new project manually before each PR, as this is not the first time we break it ?