### PR TITLE
Remove `web-console` gem

### DIFF
--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -34,7 +34,6 @@ group :development do
   gem 'foreman'
   gem 'spring'
   gem 'spring-commands-rspec'
-  gem 'web-console'
 end
 
 group :development, :test do


### PR DESCRIPTION
We use `pry` and `byebug` as a REPL and debugger.
`web-console` doesn't add much value, and sometimes annoying on small
screens as it has a `position: fixed;` at the bottom.
Having a browser inspector opened horizontally with the web-console,
hides almost Rails' error message and the stack trace.

Anyone is using it?