### PR TITLE
Upgrade rspec-rails to 3.2

### DIFF
--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -41,7 +41,7 @@ group :development, :test do
   gem 'dotenv-rails'
   gem 'factory_girl_rails'
   gem 'pry-rails'
-  gem 'rspec-rails', '~> 3.1.0'
+  gem 'rspec-rails', '~> 3.2.0'
 end
 
 group :test do


### PR DESCRIPTION
Since we removed `ActionMailer` preview path in https://github.com/craftsmen/roll/commit/f99833b3af8567b061ef40465c55cf18238687c9. We needs to upgrade to 3.2 as it's the version where `ActionMailer` preview path is configured.