### PR TITLE
 Set email deliver method to :test for development

### DIFF
--- a/lib/roll/app_builder.rb
+++ b/lib/roll/app_builder.rb
@@ -42,6 +42,23 @@ module Roll
         'raise_delivery_errors = false', 'raise_delivery_errors = true'
     end
 
+    def set_test_delivery_method
+      config = <<-RUBY
+
+
+  # Tell Action Mailer not to deliver emails to the real world.
+  # The :test delivery method accumulates sent emails in the
+  # ActionMailer::Base.deliveries array.
+  config.action_mailer.delivery_method = :test
+      RUBY
+
+      inject_into_file(
+        'config/environments/development.rb',
+        config,
+        after: 'config.action_mailer.raise_delivery_errors = true'
+      )
+    end
+
     def raise_on_unpermitted_parameters
       action_on_unpermitted_parameters = <<-RUBY
 

--- a/lib/roll/generators/app_generator.rb
+++ b/lib/roll/generators/app_generator.rb
@@ -82,6 +82,7 @@ module Roll
     def setup_development_environment
       say 'Setting up the development environment'
       build :raise_on_delivery_errors
+      build :set_test_delivery_method
       build :provide_setup_script
       build :provide_dev_prime_task
       build :configure_generators


### PR DESCRIPTION
`:test` method will not send the email, but instead print it to the
logs. This will allow faster development cycle, since there is no need
to setup smtp/sendmail when email is involved, or see `Errno::ECONNREFUSED`
errors.

We successfully used this in the last couple projects.
https://github.com/1dtouch/1dtouch-music/commit/efa711741672434f9c046eb740b22af2b634372c and https://github.com/craftsmen/cutadopters/commit/f8e47d4438c905d0e7c1e8ad5719e3fa84c3e0c6