### PR TITLE
Block all unknown urls in RSpec when using a js driver.

### DIFF
--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -45,7 +45,7 @@ group :development, :test do
 end
 
 group :test do
-  gem 'capybara-webkit', '>= 1.2.0'
+  gem 'capybara-webkit', '~> 1.5.0'
   gem 'database_cleaner'
   gem 'shoulda-matchers', require: false
   gem 'simplecov', require: false

--- a/templates/rails_helper.rb
+++ b/templates/rails_helper.rb
@@ -24,4 +24,11 @@ RSpec.configure do |config|
 end
 
 ActiveRecord::Migration.maintain_test_schema!
+
 Capybara.javascript_driver = :webkit
+
+RSpec.configure do |config|
+  config.before(:each, js: true) do
+    page.driver.block_unknown_urls
+  end
+end


### PR DESCRIPTION
* upgrade capybara-webkit to ~> 1.5 as `page.driver.block_unknown_urls`
  was introduced in 1.4

Successfully used in our latest projects.