### PR TITLE
Upgrade RSpec to 3.3 in the default Gemfile

### DIFF
--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -40,7 +40,7 @@ group :development, :test do
   gem 'dotenv-rails'
   gem 'factory_girl_rails'
   gem 'pry-rails'
-  gem 'rspec-rails', '~> 3.2.0'
+  gem 'rspec-rails', '~> 3.3.0'
 end
 
 group :test do

--- a/templates/spec_helper.rb
+++ b/templates/spec_helper.rb
@@ -10,6 +10,7 @@ RSpec.configure do |config|
     mocks.syntax = :expect
   end
 
+  config.example_status_persistence_file_path = 'tmp/rspec_examples.txt'
   config.order = :random
 end
 


### PR DESCRIPTION
RSpec 3.3 added some very handy commands for filtering examples. With
the addition of the status persistence file configuration we can now:

* run `rspec --only-failures` to re-run only the examples that failed.
* run `rspec --next-failure` to re-run only the first failing test from
  your previous run. If that passes it will run the successive failures
  until one of them fails again

Additionally, rspec 3.3 includes stable random ordering (even when you
add new examples), the ability to bisect failures when debugging
ordering-dependent failures, better failure output...

http://rspec.info/blog/2015/06/rspec-3-3-has-been-released/