### PR TITLE
Add `autoprefixer` post-processor and `browserlist` config file

### DIFF
--- a/lib/roll/app_builder.rb
+++ b/lib/roll/app_builder.rb
@@ -294,6 +294,7 @@ end
     def copy_miscellaneous_files
       copy_file 'errors.rb', 'config/initializers/errors.rb'
       copy_file 'json_encoding.rb', 'config/initializers/json_encoding.rb'
+      copy_file 'browserslist', 'browserslist'
     end
 
     def customize_error_pages

--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 ruby '<%= RUBY_VERSION %>'
 
+gem 'autoprefixer-rails'
 gem 'bourbon', '~> 4.2.0'
 gem 'coffee-rails', '~> 4.1.0'
 <% if using_active_record? -%>

--- a/templates/browserlist
+++ b/templates/browserlist
@@ -1,0 +1,1 @@
+Last 2 versions


### PR DESCRIPTION
It’s no longer best practice for pre-processors like Sass to handle
prefixing. Instead, a post-processor is better suited for this task and
allows you to write much cleaner Sass (no more `@include` for
prefixes!).

Autoprefixer is a robust, well-maintained tool to post-process
prefixes.
Autoprefixer ties into the "Can I use" database and allows you to
specify the exact browser support you need, per project. This is quite
powerful, yet painless.

We successfully experimented it in our last couple projects.