### PR TITLE
Improve `bin/setup` script for installing bundler and gems

### DIFF
--- a/templates/bin_setup
+++ b/templates/bin_setup
@@ -6,7 +6,8 @@
 set -e
 
 # Set up Ruby dependencies via Bundler
-bundle install
+gem install bundler --conservative
+bundle check || bundle install
 
 # Set up configurable environment variables
 if [ ! -f .env ]; then


### PR DESCRIPTION
This installs first Bundler then installs dependencies listed in the
Gemfile only if needed

Rails default `bin/setup` script does the same:
https://github.com/rails/rails/blob/v4.2.0/railties/lib/rails/generators/rails/app/templates/bin/setup#L11