### PR TITLE
Make the `.git/safe` directory in `bin/setup`

### DIFF
--- a/templates/bin_setup.erb
+++ b/templates/bin_setup.erb
@@ -17,6 +17,9 @@ fi
 # Set up the database
 bundle exec rake db:setup
 
+# Add binstubs to PATH via export PATH=".git/safe/../../bin:$PATH" in ~/.zshenv
+mkdir -p .git/safe
+
 # Pick a port for Foreman
 if ! grep --quiet --no-messages --fixed-strings 'port' .foreman; then
   printf 'port: <%= config[:port_number] %>\n' >> .foreman


### PR DESCRIPTION
Assuming the binstubs for a project are in the local `bin/` directory,
we can add the directory to shell `$PATH` so that `rspec` can be invoked
without the `bin/` prefix:

    export PATH="./bin:$PATH"

Doing so on a system that other people have write access to (such as a
shared host) is a security risk:

sstephenson/rbenv#309

The `.git/safe` convention addresses the security problem:

https://twitter.com/tpope/status/165631968996900865

I used to do this manually before, as I have it in my `$PATH`
https://github.com/mehlah/dotfiles/blob/master/zshenv#L12-13