### PR TITLE
Disable js assets generator

### DIFF
--- a/lib/roll/app_builder.rb
+++ b/lib/roll/app_builder.rb
@@ -88,6 +88,7 @@ module Roll
       generate.request_specs false
       generate.routing_specs false
       generate.stylesheets false
+      generate.javascripts false
       generate.test_framework :rspec
       generate.view_specs false
     end


### PR DESCRIPTION
Before, running `rails g controller pages` would generate js assets too
at `app/assets/javascripts/pages.coffee`.
We don't always need this behaviour for generated controllers (and it
was coffee :scream_cat:)