### PR TITLE
Rename `HOST` ~> `APPLICATION_HOST`

### DIFF
--- a/lib/roll/app_builder.rb
+++ b/lib/roll/app_builder.rb
@@ -219,8 +219,8 @@ end
     def configure_action_mailer
       action_mailer_host 'development', %{"localhost:#{port}"}
       action_mailer_host 'test', %{'www.example.com'}
-      action_mailer_host 'staging', %{ENV.fetch('HOST')}
-      action_mailer_host 'production', %{ENV.fetch('HOST')}
+      action_mailer_host 'staging', %{ENV.fetch('APPLICATION_HOST')}
+      action_mailer_host 'production', %{ENV.fetch('APPLICATION_HOST')}
     end
 
     def configure_active_job

--- a/templates/sample.env
+++ b/templates/sample.env
@@ -1,3 +1,3 @@
-HOST=localhost:7000
+APPLICATION_HOST=localhost:7000
 RACK_ENV=development
 SECRET_KEY_BASE=development_secret


### PR DESCRIPTION
The `$HOST` environment variable is used by zsh; overriding it affects
other programs that depend on it.

The `$HOSTNAME` environment variable is used similarly by GNU Bash.

This change the name of the environment variable that we depend on, to
avoid side effects.