### PR TITLE
No need to configure action_mailer_host in staging

### DIFF
--- a/lib/roll/app_builder.rb
+++ b/lib/roll/app_builder.rb
@@ -223,7 +223,6 @@ end
     def configure_action_mailer
       action_mailer_host 'development', %{"localhost:#{port}"}
       action_mailer_host 'test', %{'www.example.com'}
-      action_mailer_host 'staging', %{ENV.fetch('APPLICATION_HOST')}
       action_mailer_host 'production', %{ENV.fetch('APPLICATION_HOST')}
     end
 


### PR DESCRIPTION
It inherits production's, which reads the same environmental variable.