### PR TITLE
Use only one `factories.rb` file

### DIFF
--- a/lib/roll/app_builder.rb
+++ b/lib/roll/app_builder.rb
@@ -91,6 +91,7 @@ module Roll
       generate.javascripts false
       generate.test_framework :rspec
       generate.view_specs false
+      generate.factory_girl false
     end
 
       RUBY

--- a/lib/roll/app_builder.rb
+++ b/lib/roll/app_builder.rb
@@ -104,12 +104,16 @@ module Roll
       copy_file 'style_guides/javascript.json', 'config/style_guides/javascript.json'
     end
 
+    def generate_rspec
+      generate 'rspec:install'
+    end
+
     def set_up_factory_girl_for_rspec
       copy_file 'factory_girl_rspec.rb', 'spec/support/factory_girl.rb'
     end
 
-    def generate_rspec
-      generate 'rspec:install'
+    def generate_factories_file
+      copy_file 'factories.rb', 'spec/factories.rb'
     end
 
     def configure_rspec

--- a/lib/roll/generators/app_generator.rb
+++ b/lib/roll/generators/app_generator.rb
@@ -91,8 +91,9 @@ module Roll
 
     def setup_test_environment
       say 'Setting up the test environment'
-      build :set_up_factory_girl_for_rspec
       build :generate_rspec
+      build :set_up_factory_girl_for_rspec
+      build :generate_factories_file
       build :configure_rspec
       build :configure_background_jobs_for_rspec
       build :enable_database_cleaner

--- a/templates/factories.rb
+++ b/templates/factories.rb
@@ -1,0 +1,2 @@
+FactoryGirl.define do
+end


### PR DESCRIPTION
In recent projects, we experimented using only one factories. We've seen
some benefits like sharing sequences and less navigation between files when
writing specs. We decided to go this way by default in our next projects,
and split the factories to multiple files only when needed.