### PR TITLE
Use Heroku Local (Forego) instead of Foreman

### DIFF
--- a/lib/roll/app_builder.rb
+++ b/lib/roll/app_builder.rb
@@ -286,7 +286,7 @@ end
       copy_file 'unicorn.rb', 'config/unicorn.rb'
     end
 
-    def setup_foreman
+    def setup_forego
       copy_file 'sample.env', '.sample.env'
       copy_file 'Procfile', 'Procfile'
     end

--- a/lib/roll/generators/app_generator.rb
+++ b/lib/roll/generators/app_generator.rb
@@ -140,7 +140,7 @@ module Roll
       build :disable_xml_params
       build :setup_default_rake_task
       build :configure_unicorn
-      build :setup_foreman
+      build :setup_forego
       build :raise_on_unpermitted_parameters
     end
 

--- a/templates/README.md.erb
+++ b/templates/README.md.erb
@@ -6,8 +6,8 @@ This repository comes equipped with a self-setup script!
 
     % ./bin/setup
 
-After setting up, you can run the application using [foreman]:
+After setting up, you can run the application using [Heroku Local]:
 
-    % foreman start
+    % heroku local
 
-[foreman]: http://ddollar.github.io/foreman/
+[Heroku Local]: https://devcenter.heroku.com/articles/heroku-local

--- a/templates/bin_setup.erb
+++ b/templates/bin_setup.erb
@@ -19,8 +19,3 @@ bundle exec rake db:setup
 
 # Add binstubs to PATH via export PATH=".git/safe/../../bin:$PATH" in ~/.zshenv
 mkdir -p .git/safe
-
-# Pick a port for Foreman
-if ! grep --quiet --no-messages --fixed-strings 'port' .foreman; then
-  printf 'port: <%= config[:port_number] %>\n' >> .foreman
-fi

--- a/templates/roll_gitignore
+++ b/templates/roll_gitignore
@@ -4,7 +4,6 @@
 *.swp
 .bundle
 .env
-.foreman
 coverage/*
 db/*.sqlite3
 log/*

--- a/templates/sample.env
+++ b/templates/sample.env
@@ -1,3 +1,4 @@
 APPLICATION_HOST=localhost:7000
+PORT=7000
 RACK_ENV=development
 SECRET_KEY_BASE=development_secret


### PR DESCRIPTION
Heroku Local has replaced Foreman in the Heroku Toolbelt.

https://devcenter.heroku.com/changelog-items/692

The command `heroku local` has replaced `foreman`.
Heroku Local makes use of [Forego] to accomplish its tasks
and it is faster and has better cross-platform support.

[Forego]: https://github.com/ddollar/forego