### PR TITLE
Raise on missing Sprockets assets in test

### DIFF
--- a/lib/roll/app_builder.rb
+++ b/lib/roll/app_builder.rb
@@ -59,6 +59,21 @@ module Roll
       )
     end
 
+    def raise_on_missing_assets_in_test
+      config = <<-RUBY
+
+
+  # Raise an error on missing Sprockets assets
+  config.assets.raise_runtime_errors = true
+      RUBY
+
+      inject_into_file(
+        'config/environments/test.rb',
+        config,
+        after: 'Rails.application.configure do',
+      )
+    end
+
     def raise_on_unpermitted_parameters
       action_on_unpermitted_parameters = <<-RUBY
     # Raise an ActionController::UnpermittedParameters exception when

--- a/lib/roll/generators/app_generator.rb
+++ b/lib/roll/generators/app_generator.rb
@@ -83,6 +83,7 @@ module Roll
       say 'Setting up the development environment'
       build :raise_on_delivery_errors
       build :set_test_delivery_method
+      build :raise_on_missing_assets_in_test
       build :provide_setup_script
       build :provide_dev_prime_task
       build :configure_generators


### PR DESCRIPTION
When testing features, we'd prefer to be notified of asset pipeline
issues as early as possible.