### PR TITLE
Set default Heroku remote to staging

### DIFF
--- a/lib/roll/app_builder.rb
+++ b/lib/roll/app_builder.rb
@@ -386,12 +386,13 @@ end
     end
 
     def set_heroku_remotes
-      remotes = <<-RUBY
+      remotes = <<-SHELL
 
 # Set up staging and production git remotes
 git remote add staging git@heroku.com:#{app_name}-staging.git
 git remote add production git@heroku.com:#{app_name}-production.git
-      RUBY
+git config heroku.remote staging
+      SHELL
 
       append_file 'bin/setup', remotes
     end


### PR DESCRIPTION
This saves adding a `--remote staging` to Heroku commands for staging
apps.
Using `--remote production` works as usual for production apps.