### PR TITLE
Let Travis use `rake` binstub instead

### DIFF
--- a/templates/travis.yml.erb
+++ b/templates/travis.yml.erb
@@ -16,7 +16,7 @@ before_install:
 
 before_script:
   - cp .sample.env .env
-  - bundle exec rake db:create db:schema:load RAILS_ENV=test
+  - bin/rake db:create db:schema:load RAILS_ENV=test
 
 notifications:
   email: false


### PR DESCRIPTION
There is no need to use `bundle exec` given we have binstub in `bin/`.