### PR TITLE
Run `dev:prime` in `bin/setup` instead of `db:setup`

### DIFF
--- a/templates/bin_setup.erb
+++ b/templates/bin_setup.erb
@@ -14,8 +14,8 @@ if [ ! -f .env ]; then
   cp .sample.env .env
 fi
 
-# Set up the database
-bundle exec rake db:setup
+# Set up the database and add any development seed data
+bin/rake dev:prime
 
 # Add binstubs to PATH via export PATH=".git/safe/../../bin:$PATH" in ~/.zshenv
 mkdir -p .git/safe


### PR DESCRIPTION
`dev:prime` already depends on `db:setup`. Calling it in `bin/setup` is
more convenient.
Additionally, the generated Rails application uses Bundler's binstubs,
so we can replace `bundle exec rake` with `bin/rake`.