### PR TITLE
Remove JavaScript default style guide overrides for Hound

### DIFF
--- a/lib/roll/app_builder.rb
+++ b/lib/roll/app_builder.rb
@@ -125,7 +125,6 @@ module Roll
     def configure_hound
       copy_file 'hound.yml', '.hound.yml'
       copy_file 'style_guides/ruby.yml', 'config/style_guides/ruby.yml'
-      copy_file 'style_guides/javascript.json', 'config/style_guides/javascript.json'
     end
 
     def generate_rspec

--- a/templates/hound.yml
+++ b/templates/hound.yml
@@ -4,7 +4,6 @@ ruby:
 
 java_script:
   enabled: true
-  config_file: config/style_guides/javascript.json
 
 scss:
   enabled: true

--- a/templates/style_guides/javascript.json
+++ b/templates/style_guides/javascript.json
@@ -1,3 +1,0 @@
-{
-  "camelcase": false
-}


### PR DESCRIPTION
We agreed to use a camelcase style for our JavaScript code to avoid the
inconsistencies due to 3rd party JS libraries.