### PR TITLE
Inject Spring into binstubs

### DIFF
--- a/lib/roll/app_builder.rb
+++ b/lib/roll/app_builder.rb
@@ -394,6 +394,10 @@ end
       run 'git init'
     end
 
+    def setup_spring
+      bundle_command 'exec spring binstub --all'
+    end
+
     def create_heroku_apps(flags)
       %w(staging production).each do |environment|
         run "heroku create #{app_name}-#{environment} --remote #{environment} #{flags}"

--- a/lib/roll/generators/app_generator.rb
+++ b/lib/roll/generators/app_generator.rb
@@ -44,6 +44,7 @@ module Roll
       invoke :customize_error_pages
       invoke :remove_routes_comment_lines
       invoke :setup_git
+      invoke :setup_spring
       invoke :create_heroku_apps
       invoke :outro
     end
@@ -185,6 +186,11 @@ module Roll
 
     def init_git
       build :init_git
+    end
+
+    def setup_spring
+      say 'Springifying binstubs'
+      build :setup_spring
     end
 
     def create_heroku_apps


### PR DESCRIPTION
Spring makes Rails applications load faster, but it might introduce
confusing issues around stale code not being refreshed.

I prefer not use spring by default. I added `DISABLE_SPRING=1` to my ENV
variables to disable it system-wide.

@kevcha if you share the same opinion, we can remove totally Spring from Roll.