### PR TITLE
Promote newrelic_rpm gem to global group

### DIFF
--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -17,6 +17,7 @@ gem 'jquery-rails'
 gem 'mongoid', github: 'mongoid/mongoid'
 <% end -%>
 gem 'neat', '~> 1.7.0'
+gem 'newrelic_rpm'
 gem 'normalize-rails', '~> 3.0.0'
 <% if using_active_record? -%>
 gem 'pg'
@@ -54,6 +55,5 @@ group :test do
 end
 
 group :staging, :production do
-  gem 'newrelic_rpm'
   gem 'rack-timeout'
 end


### PR DESCRIPTION
There is no reason not to have it in the global group.