### PR TITLE
Fix injection of rails_stdout_logging gem to the Gemfile

### DIFF
--- a/lib/roll/generators/app_generator.rb
+++ b/lib/roll/generators/app_generator.rb
@@ -53,7 +53,7 @@ module Roll
       build :replace_gemfile
       build :set_ruby_to_version_being_used
 
-      if options[:heroku]
+      if !options[:skip_heroku]
         build :setup_heroku_specific_gems
       end
 


### PR DESCRIPTION
Due to a bad conditional, this gem was never injected automatically.
We used to add it to our projects afterwards.