### PR TITLE
Remove support of `skip-git` option

### DIFF
--- a/lib/roll/generators/app_generator.rb
+++ b/lib/roll/generators/app_generator.rb
@@ -173,18 +173,8 @@ module Roll
     end
 
     def setup_git
-      if !options[:skip_git]
-        say 'Initializing git'
-        invoke :setup_gitignore
-        invoke :init_git
-      end
-    end
-
-    def setup_gitignore
+      say 'Initializing git'
       build :gitignore_files
-    end
-
-    def init_git
       build :init_git
     end
 


### PR DESCRIPTION
There is no reason or need to roll a new app without Git.
Doing so breaks Heroku setup as we need to setup Git remotes.
This commit removes the support of this option until we really need it.