### PR TITLE
Raise an exception on missing translations

### DIFF
--- a/lib/roll/app_builder.rb
+++ b/lib/roll/app_builder.rb
@@ -80,6 +80,14 @@ module Roll
       )
     end
 
+    def raise_on_missing_translations
+      config = 'config.action_view.raise_on_missing_translations = true'
+
+      %w(test development).each do |environment|
+        uncomment_lines "config/environments/#{environment}.rb", config
+      end
+    end
+
     def raise_on_unpermitted_parameters
       action_on_unpermitted_parameters = <<-RUBY
     # Raise an ActionController::UnpermittedParameters exception when

--- a/lib/roll/generators/app_generator.rb
+++ b/lib/roll/generators/app_generator.rb
@@ -85,6 +85,7 @@ module Roll
       build :raise_on_delivery_errors
       build :set_test_delivery_method
       build :raise_on_missing_assets_in_test
+      build :raise_on_missing_translations
       build :provide_setup_script
       build :provide_dev_prime_task
       build :configure_generators


### PR DESCRIPTION
Raising an exception ensures that all of your calls to `t()`
are using your copy, instead of using a default string.

Lesson learned from Chaperone project.