### PR TITLE
Add a JavaScript linter config for Hound with ES6 syntax enabled

### DIFF
--- a/lib/roll/app_builder.rb
+++ b/lib/roll/app_builder.rb
@@ -118,6 +118,7 @@ module Roll
     def configure_hound
       copy_file 'hound.yml', '.hound.yml'
       copy_file 'linters/ruby.yml', 'config/linters/ruby.yml'
+      copy_file 'linters/javascript.json', 'config/linters/javascript.json'
     end
 
     def raise_on_missing_assets_in_test

--- a/templates/hound.yml
+++ b/templates/hound.yml
@@ -4,6 +4,7 @@ ruby:
 
 java_script:
   enabled: true
+  config_file: config/linters/javascript.json
 
 scss:
   enabled: true

--- a/templates/linters/javascript.json
+++ b/templates/linters/javascript.json
@@ -1,0 +1,3 @@
+{
+  "esnext": true
+}


### PR DESCRIPTION
We decided to default to ES6 for our last project and the upcoming ones.
This PR enables ES6 syntax linting for Hound.